### PR TITLE
Do not overwrite the ovirt-vmconsole-proxy sshd_config file during updates

### DIFF
--- a/ovirt-vmconsole.spec.in
+++ b/ovirt-vmconsole.spec.in
@@ -202,6 +202,7 @@ install -m 644 "src/ovirt-vmconsole-proxy/ovirt-vmconsole-proxy-sshd/ovirt-vmcon
 %{_sysconfdir}/pki/%{name}/
 
 %files host
+%config(noreplace) %{_datadir}/ovirt-vmconsole/ovirt-vmconsole-host/ovirt-vmconsole-host-sshd/sshd_config
 %{_datadir}/%{name}/ovirt-vmconsole-host/
 %{_libexecdir}/ovirt-vmconsole-host-*
 %{_sysconfdir}/%{name}/ovirt-vmconsole-host/
@@ -209,6 +210,8 @@ install -m 644 "src/ovirt-vmconsole-proxy/ovirt-vmconsole-proxy-sshd/ovirt-vmcon
 %{_unitdir}/ovirt-vmconsole-host-sshd.service
 
 %files proxy
+%config(noreplace) %{_datadir}/ovirt-vmconsole/ovirt-vmconsole-proxy/ssh_config
+%config(noreplace) %{_datadir}/ovirt-vmconsole/ovirt-vmconsole-proxy/ovirt-vmconsole-proxy-sshd/sshd_config
 %{_datadir}/%{name}/ovirt-vmconsole-proxy/
 %{_libexecdir}/ovirt-vmconsole-proxy-*
 %{_sysconfdir}/%{name}/ovirt-vmconsole-proxy/

--- a/ovirt-vmconsole.spec.in
+++ b/ovirt-vmconsole.spec.in
@@ -210,8 +210,6 @@ install -m 644 "src/ovirt-vmconsole-proxy/ovirt-vmconsole-proxy-sshd/ovirt-vmcon
 %{_unitdir}/ovirt-vmconsole-host-sshd.service
 
 %files proxy
-%config(noreplace) %{_datadir}/ovirt-vmconsole/ovirt-vmconsole-proxy/ssh_config
-%config(noreplace) %{_datadir}/ovirt-vmconsole/ovirt-vmconsole-proxy/ovirt-vmconsole-proxy-sshd/sshd_config
 %{_datadir}/%{name}/ovirt-vmconsole-proxy/
 %{_libexecdir}/ovirt-vmconsole-proxy-*
 %{_sysconfdir}/%{name}/ovirt-vmconsole-proxy/


### PR DESCRIPTION

Do not overwrite the ovirt-vmconsole-proxy sshd_config file during updates. 

Issue:
When updating ovirt-vmconsole packages the ovirt-vmconsole-proxy sshd_config
file is being overwritten.

Fix:
Update the spec file to mark sshd config for ovirt-vmconsole-host-sshd as config file by adding config(noreplace) macro.

Signed-off-by: Shubha Kulkarni <shubha.kulkarni@oracle.com>
