### PR TITLE
mark git repo directory as safe for automation

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,9 +1,14 @@
-.PHONY: installdeps srpm
+.PHONY: installdeps git_cfg_safe srpm
 
 installdeps:
 	dnf -y install git autoconf automake make gettext-devel openssh-clients openssh-server python3-devel gcc
 
-srpm: installdeps
+git_cfg_safe: installdeps
+	# From git 2.35.2 we need to mark temporary directory, where the project is cloned to, as safe, otherwise
+	# git commands won't work because of the fix for CVE-2022-24765
+	git config --global --add safe.directory "$(shell pwd)"
+
+srpm: git_cfg_safe
 	$(eval SUFFIX=$(shell sh -c " echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
 	mkdir -p tmp.repos/SOURCES
 	autopoint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Mark repository as safe
+        run: git config --global --add safe.directory "$(pwd)"
       - name: Check patch
         run: ./automation/check-patch.sh
       - name: Upload artifacts


### PR DESCRIPTION
Solves build error on el9.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>