### PR TITLE
spec: Adjust selinux requirement for stable upstream releases

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "oVirt VMConsole Development",
+  "image": "quay.io/centos/centos:stream10",
+  "postCreateCommand": "dnf update -y && dnf install -y sudo",
+  "remoteUser": "root",
+  "workspaceFolder": "/workspace",
+  "mounts": [
+    "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached"
+  ]
+}

--- a/ovirt-vmconsole.spec.in
+++ b/ovirt-vmconsole.spec.in
@@ -24,6 +24,17 @@ BuildRequires:	openssh-server
 BuildRequires:	selinux-policy-devel
 BuildRequires:  selinux-policy
 BuildArch:	noarch
+
+# For upstream require at least the version from the latest stable release. (>=)
+# TODO: remove those hard-coded values once we're able
+# to build RPMs in chroots based on latest stable releases.
+%if 0%{?rhel} == 9
+%global _selinux_policy_version 38.1.53-5.el9_6
+%endif
+%if 0%{?rhel} == 10
+%global _selinux_policy_version 40.13.26-1.el10
+%endif
+
 %{?selinux_requires}
 
 BuildRequires:	python3-devel


### PR DESCRIPTION
Updated version of: https://github.com/oVirt/ovirt-vmconsole/pull/4

We still don't have access to chroots of stable releases, at least on CBS we don't. So, there is no good alternative to hardcoding the selinux policy versions. 

Updated rhel 9 to the latest version and also added a version for rhel 10.